### PR TITLE
Job to welcome referrals

### DIFF
--- a/apps/api/models/content-module.js
+++ b/apps/api/models/content-module.js
@@ -100,7 +100,12 @@ export const airtableToModel = record => {
     .get()
   const pEls = $('body > p')
     .map((i, el) => {
-      const text = $(el).clone().children().remove().end().text()
+      const text = $(el)
+        .clone()
+        .children()
+        .remove()
+        .end()
+        .text()
       return { tag: $(el).get(0).tagName, text }
     })
     .get()
@@ -115,7 +120,8 @@ export const airtableToModel = record => {
   }, {})
   const images = args => {
     return record.images.map(image => ({
-      url: `${APP_URL}/api/image?` +
+      url:
+        `${APP_URL}/api/image?` +
         qs.stringify({
           url: image.url,
           width: args.width,

--- a/apps/jobs/lib/referral-welcome.js
+++ b/apps/jobs/lib/referral-welcome.js
@@ -1,0 +1,16 @@
+/**
+ * If a PCP referral is added as a lead to Airtable either via our secret web
+ * form or converted from eFax, we invite them to schedule a consult.
+ */
+import * as notifications from './notifications'
+
+const { APP_URL } = process.env
+
+export default async () =>
+  notifications.sendToleads({
+    notificationName: 'referralWelcome',
+    filter: "{Signup Stage} = 'referral'",
+    variables: lead => ({
+      scheduleConsultUrl: `${APP_URL}/consult-schedule?leadId=${lead.id}`
+    })
+  })

--- a/apps/portal/pages/consult-schedule.js
+++ b/apps/portal/pages/consult-schedule.js
@@ -84,7 +84,7 @@ export default class ConsultSchedule extends React.Component {
         onClick={this.nextStep}
         disabled={
           this.state.disabledNext &&
-            this.state.consentedNum <= this.props.consent.li.length - 1
+          this.state.consentedNum <= this.props.consent.li.length - 1
         }
       >
         {text}
@@ -141,7 +141,8 @@ export default class ConsultSchedule extends React.Component {
         <ul>
           {this.props.consent.li.map(text => (
             <li key={text}>
-              {text}<input onChange={onCheck} type='checkbox' />
+              {text}
+              <input onChange={onCheck} type='checkbox' />
             </li>
           ))}
         </ul>

--- a/apps/portal/test/pages/consult-schedule.test.js
+++ b/apps/portal/test/pages/consult-schedule.test.js
@@ -4,10 +4,10 @@ import { shallow } from 'enzyme'
 test('renders Clinko', () => {
   const wrapper = shallow(
     <ImprintSchedule
-      step0={{ h1: 'hi ', a: 'foo', images: [{ url: 'foo' }] }}
-      step2={{ h1: 'hi ', images: [{ url: 'foo' }] }}
+      welcome={{ h1: 'hi ', a: 'foo', images: [{ url: 'foo' }] }}
+      calendar={{ h1: 'hi ', images: [{ url: 'foo' }] }}
     />
   )
-  wrapper.setState({ step: 2 })
+  wrapper.setState({ step: 1 })
   expect(wrapper.html()).toContain('cliniko.com')
 })


### PR DESCRIPTION
Similar to the "pre-boarding" notifications from before, this just finds leads who are marked ~preboarding~ `referral` and sends them an invite to schedule a consult.